### PR TITLE
My sampler update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 description = 'Java MYA API'
 group 'org.jlab'
-version '6.2.0'
+version '6.3.0'
 
 tasks.withType(JavaCompile) {
     options.release = 8

--- a/src/main/java/org/jlab/mya/nexus/DataNexus.java
+++ b/src/main/java/org/jlab/mya/nexus/DataNexus.java
@@ -330,7 +330,9 @@ public abstract class DataNexus {
      * @param sampleCount The number of samples
      * @return A new EventStream
      * @throws SQLException If unable to query the database
+     * @deprecated use {@link org.jlab.mya.stream.MySamplerStream} instead.
      */
+    @Deprecated
     public EventStream<FloatEvent> openMySamplerStream(Metadata<FloatEvent> metadata, Instant begin, long stepMilliseconds, long sampleCount) throws
             SQLException {
         return sourceSampleService.openMySamplerFloatStream(metadata, begin, stepMilliseconds, sampleCount);

--- a/src/main/java/org/jlab/mya/nexus/MySamplerFloatEventStream.java
+++ b/src/main/java/org/jlab/mya/nexus/MySamplerFloatEventStream.java
@@ -16,7 +16,9 @@ import org.jlab.mya.event.FloatEvent;
  * Unlike a standard EventStream this one actually creates a new ResultSet for each sample.
  * 
  * @author slominskir
+ * @deprecated  use {@link org.jlab.mya.stream.MySamplerStream} instead
  */
+@Deprecated
 class MySamplerFloatEventStream extends FloatEventStream {
 
     private Instant begin;

--- a/src/main/java/org/jlab/mya/nexus/SourceSamplingService.java
+++ b/src/main/java/org/jlab/mya/nexus/SourceSamplingService.java
@@ -113,7 +113,9 @@ class SourceSamplingService extends QueryService {
      * @param sampleCount The number of samples
      * @return A new FloatEventStream
      * @throws SQLException If unable to query the database
+     * @deprecated use {@link org.jlab.mya.stream.MySamplerStream} instead.
      */
+    @Deprecated
     public EventStream<FloatEvent> openMySamplerFloatStream(Metadata<FloatEvent> metadata, Instant begin, long stepMilliseconds, long sampleCount) throws
             SQLException {
         String host = metadata.getHost();

--- a/src/main/java/org/jlab/mya/stream/MySamplerStream.java
+++ b/src/main/java/org/jlab/mya/stream/MySamplerStream.java
@@ -62,6 +62,7 @@ public class MySamplerStream<T extends Event> extends BoundaryAwareStream<T> {
      * @return The next sample event or null if future.
      * @throws IOException If unable to read the next event
      */
+    @SuppressWarnings("unchecked")
     public T read() throws IOException {
 
         // Have we got all of our samples?  Was there no data here to start?  Return null to indicate there is nothing

--- a/src/main/java/org/jlab/mya/stream/MySamplerStream.java
+++ b/src/main/java/org/jlab/mya/stream/MySamplerStream.java
@@ -1,0 +1,152 @@
+package org.jlab.mya.stream;
+
+import org.jlab.mya.TimeUtil;
+import org.jlab.mya.event.Event;
+
+import java.io.IOException;
+import java.time.Instant;
+
+/**
+ * This is a class that attempts to mimic the commandline mySampler application.  You specify the start time, sample
+ * interval in terms of time, and the number of samples, along with an EventStream and prior Event that contains the data
+ * to be sampled from.
+ * @param <T> The Event type (FloatEvent, IntEvent, etc.)
+ */
+public class MySamplerStream<T extends Event> extends BoundaryAwareStream<T> {
+
+    private final long intervalMillis;
+    private final long sampleCount;
+    private long samplesTaken = 0L;
+    private long sampleTimeMya;
+    private Instant sampleTimeInstant;
+    private T currentEvent = null;
+    private T previousEvent = null;
+    private boolean firstRead = true;
+    private boolean endOfStream = false;
+
+    /**
+     * Create an instance of MySamplerStream.  This extends a special case of the BoundaryAwareStream that always has
+     * priorPoint supplied.  The BoundaryAwareStream has 'begin' and 'end' values that match the first and last sample
+     * needed in the mySamplerStream.
+     *
+     * @param wrapped        A stream of Events to be sampled from
+     * @param begin          The time of the first sample
+     * @param intervalMillis The time interval between samples in milliseconds
+     * @param sampleCount    The number of samples to take, including the first one at begin
+     * @param priorPoint     The Event prior to begin.  It's required to be non-null.
+     * @param updatesOnly    Should the final event from the BoundaryAwareStream only be an update event.
+     * @param type           The type of Event produced by the wrapped stream
+     */
+    public MySamplerStream(EventStream<T> wrapped, Instant begin, long intervalMillis, long sampleCount, T priorPoint,
+                           boolean updatesOnly, Class<T> type) {
+        super(wrapped, begin, begin.plusMillis(intervalMillis * (sampleCount - 1)), priorPoint, updatesOnly,
+                type);
+        if (priorPoint == null) {
+            throw new IllegalArgumentException("mySamplerStream requires a non-null priorPoint.");
+        }
+        this.intervalMillis = intervalMillis;
+        this.sampleCount = sampleCount;
+        this.sampleTimeMya = TimeUtil.toMyaTimestamp(begin);
+        this.sampleTimeInstant = begin;
+    }
+
+    /**
+     * This does in app sampling of the full data stream.  The basic idea is to return the value of the signal only at
+     * the times that were requested based on sampling parameters.  Events are created so that timestamps are at sample
+     * times.  null is returned when requesting the future.
+     * <p>
+     * We maintained two event update points.  When they straddle the sample time, we read out an event with the sample
+     * time timestamp, but the value and code of the previous update event.  Each read from this stream will iterate
+     * over the wrapped stream until we find two points that straddle the sample time or the end of the stream.
+     *
+     * @return The next sample event or null if future.
+     * @throws IOException If unable to read the next event
+     */
+    public T read() throws IOException {
+
+        // Have we got all of our samples?  Was there no data here to start?  Return null to indicate there is nothing
+        // left to read.
+        if (endOfStream) {
+            return null;
+        }
+
+        // On the first read, we need to get both current and previous to jump start the algorithm.  This should
+        // skip through the later while loop to return the first point.
+        if (firstRead) {
+            firstRead = false;
+            previousEvent = super.read();
+            currentEvent = super.read();
+
+            // No data found in the stream, mark the end of the stream.
+            if (previousEvent == null) {
+                endOfStream = true;
+                return null;
+            }
+        }
+
+        // If you've run past the final bounded value, add an event point at the next sample time.
+        if (currentEvent == null) {
+            //noinspection unchecked
+            currentEvent = (T) previousEvent.copyTo(sampleTimeInstant);
+        }
+
+        // We need to work through the stream to find the next sample point.  We want the points straddling the sample
+        // time.
+        while (determinePosition(previousEvent, currentEvent, sampleTimeMya) < 0) {
+            previousEvent = currentEvent;
+            currentEvent = super.read();
+
+            // We've reached the end of the event stream.  Put currentEvent out to the next sample point, so we now
+            // straddle the current sample point.  This works for continued sampling into the future with only a single
+            // pass through the loop.
+            if (currentEvent == null) {
+                //noinspection SingleStatementInBlock,unchecked
+                currentEvent = (T) previousEvent.copyTo(sampleTimeInstant.plusMillis(intervalMillis));
+            }
+        }
+
+        // Take the sample
+        //noinspection unchecked
+        T out = (T) previousEvent.copyTo(sampleTimeInstant);
+        moveSampleCursor();
+
+        return out;
+    }
+
+    /**
+     * Move the sample cursor (timestamp of next sample) forward by the requested interval.  Track if we have taken
+     * enough samples.
+     */
+    void moveSampleCursor() {
+        sampleTimeInstant = sampleTimeInstant.plusMillis(intervalMillis);
+        sampleTimeMya = TimeUtil.toMyaTimestamp(sampleTimeInstant);
+        samplesTaken++;
+        if (samplesTaken >= sampleCount) {
+            endOfStream = true;
+        }
+    }
+
+    /**
+     * Determine the position of the two events relative to the desired sample time.  Events e1 and e2 cannot be null.
+     * Required that e1.getTimestamp() <= e2.getTimestamp().
+     *
+     * @param e1     First event
+     * @param e2     Second event
+     * @param sample sample timestamp
+     * @return -1 if both are before, 1 if both are after, 0 if they straddle it
+     */
+    private int determinePosition(T e1, T e2, long sample) {
+        if (e2.getTimestamp() < e1.getTimestamp()) {
+            throw new IllegalArgumentException("e2 cannot be before e1.");
+        }
+
+        if (e1.getTimestamp() > sample) {
+            return 1;
+        } else if (e2.getTimestamp() <= sample) {
+            return -1;
+        } else {
+            // e1 <= sample < e2
+            return 0;
+        }
+    }
+}

--- a/src/test/java/org/jlab/mya/stream/MySamplerStreamTest.java
+++ b/src/test/java/org/jlab/mya/stream/MySamplerStreamTest.java
@@ -1,0 +1,326 @@
+package org.jlab.mya.stream;
+
+import org.jlab.mya.TimeUtil;
+import org.jlab.mya.event.EventCode;
+import org.jlab.mya.event.FloatEvent;
+import org.jlab.mya.event.IntEvent;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+
+public class MySamplerStreamTest {
+
+    /**
+     * A method for comparing lists of FloatEvents for equality.  FloatEvent does not have an equals() method, so this
+     * is about the best to be done here.
+     *
+     * @param exp    The expected list
+     * @param result The actual list
+     */
+    public static void assertFloatEventListEquals(List<FloatEvent> exp, List<FloatEvent> result) {
+        // Event does not define equals, so this is about as good as it gets.
+        assertEquals("Received a different number of events than expected", exp.size(), result.size());
+        for (int i = 0; i < exp.size(); i++) {
+            assertEquals("Mismatch at event " + i, exp.get(i).toString(), result.get(i).toString());
+        }
+    }
+
+    /**
+     * A method for comparing lists of IntEvents for equality.  IntEvent does not have an equals() method, so this
+     * is about the best to be done here.
+     *
+     * @param exp    The expected list
+     * @param result The actual list
+     */
+    public static void assertIntEventListEquals(List<IntEvent> exp, List<IntEvent> result) {
+        // Event does not define equals, so this is about as good as it gets.
+        assertEquals("Received a different number of events than expected", exp.size(), result.size());
+        for (int i = 0; i < exp.size(); i++) {
+            assertEquals("Mismatch at event " + i, exp.get(i).toString(), result.get(i).toString());
+        }
+    }
+
+    /**
+     * This test checks that the basic sampling functionality works.
+     *
+     * @throws IOException On error reading from underlying stream
+     */
+    @Test
+    public void basicUsageTest() throws IOException {
+        // Instant begin = TimeUtil.toLocalDT("2019-08-12T00:00:20");
+        // Instant end = TimeUtil.toLocalDT("2019-08-12T00:01:00.");
+        // With five samples of 10s we should get samples at 00:20, 00:30, 00:40, 00:50, 01:00
+        //  2019-08-12 00:00:17.289774 94.7978 -> 2019-08-12 00:00:20 94.7978
+        //  2019-08-12 00:00:27.296512 95.6075 -> 2019-08-12 00:00:30 95.6075
+        //  2019-08-12 00:00:38.329526 95.1736 -> 2019-08-12 00:00:40 95.1736
+        //  2019-08-12 00:00:47.347886 95.2913 -> 2019-08-12 00:00:50 95.2913
+        //  2019-08-12 00:00:59.311013 95.7036 -> 2019-08-12 00:00:60 95.7036
+
+        // The stream to sample from
+        FloatEvent priorPoint = new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:17.28"), EventCode.UPDATE, 94.7978f);
+        List<FloatEvent> events = new ArrayList<>();
+        events.add(new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:23.32"), EventCode.UPDATE, 95.0715f));
+        events.add(new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:23.42"), EventCode.UPDATE, 0.0715f));
+        events.add(new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:23.52"), EventCode.UPDATE, 1.0715f));
+        events.add(new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:23.62"), EventCode.UPDATE, 2.0715f));
+        events.add(new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:27.27"), EventCode.UPDATE, 95.6075f));
+        events.add(new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:32.27"), EventCode.UPDATE, 95.3278f));
+        events.add(new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:38.32"), EventCode.UPDATE, 95.1736f));
+        events.add(new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:40.33"), EventCode.UPDATE, 95.0677f));
+        events.add(new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:47.34"), EventCode.UNDEFINED, 0f));
+        events.add(new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:51.29"), EventCode.UPDATE, 95.4232f));
+        events.add(new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:59.31"), EventCode.UPDATE, 95.7036f));
+
+        Instant begin = TimeUtil.toLocalDT("2019-08-12T00:00:20.0");
+        long stepMilliseconds = 10_000; // ten second sample interval
+        long sampleCount = 5;
+        boolean updatesOnly = false;
+
+        // Generate the expected list
+        List<FloatEvent> exp = new ArrayList<>();
+        exp.add(new FloatEvent(TimeUtil.toMyaTimestamp(begin), EventCode.UPDATE, 94.7978f));
+        exp.add(new FloatEvent(TimeUtil.toMyaTimestamp(begin.plusMillis(stepMilliseconds)), EventCode.UPDATE, 95.6075f));
+        exp.add(new FloatEvent(TimeUtil.toMyaTimestamp(begin.plusMillis(2 * stepMilliseconds)), EventCode.UPDATE, 95.1736f));
+        exp.add(new FloatEvent(TimeUtil.toMyaTimestamp(begin.plusMillis(3 * stepMilliseconds)), EventCode.UNDEFINED, 0f));
+        exp.add(new FloatEvent(TimeUtil.toMyaTimestamp(begin.plusMillis(4 * stepMilliseconds)), EventCode.UPDATE, 95.7036f));
+
+
+        List<FloatEvent> result = new ArrayList<>();
+        try (EventStream<FloatEvent> stream = new MySamplerStream<>(new ListStream<>(events, FloatEvent.class), begin,
+                stepMilliseconds, sampleCount, priorPoint, updatesOnly, FloatEvent.class)) {
+            FloatEvent event;
+            while ((event = stream.read()) != null) {
+                result.add(event);
+                System.out.println(event);
+            }
+        }
+
+        assertFloatEventListEquals(exp, result);
+    }
+
+
+    /**
+     * This test checks that the basic sampling functionality works.
+     *
+     * @throws IOException On error reading from underlying stream.
+     */
+    @Test
+    public void basicUsageUpdatesOnlyTest() throws IOException {
+        // Instant begin = TimeUtil.toLocalDT("2019-08-12T00:00:20");
+        // Instant end = TimeUtil.toLocalDT("2019-08-12T00:01:00.");
+        // With five samples of 10s we should get samples at 00:20, 00:30, 00:40, 00:50, 01:00
+        //  2019-08-12 00:00:17.289774 94.7978 -> 2019-08-12 00:00:20 94.7978
+        //  2019-08-12 00:00:27.296512 95.6075 -> 2019-08-12 00:00:30 95.6075
+        //  2019-08-12 00:00:38.329526 95.1736 -> 2019-08-12 00:00:40 95.1736
+        //  2019-08-12 00:00:47.347886 95.2913 -> 2019-08-12 00:00:50 95.2913
+        //  2019-08-12 00:00:59.311013 95.7036 -> 2019-08-12 00:00:60 95.7036
+
+        // The stream to sample from
+        FloatEvent priorPoint = new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:17.28"), EventCode.UPDATE, 94.7978f);
+        List<FloatEvent> events = new ArrayList<>();
+        events.add(new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:23.32"), EventCode.UPDATE, 95.0715f));
+        events.add(new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:23.42"), EventCode.UPDATE, 0.0715f));
+        events.add(new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:23.52"), EventCode.UPDATE, 1.0715f));
+        events.add(new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:23.62"), EventCode.UPDATE, 2.0715f));
+        events.add(new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:27.27"), EventCode.UPDATE, 95.6075f));
+        events.add(new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:32.27"), EventCode.UPDATE, 95.3278f));
+        events.add(new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:38.32"), EventCode.UPDATE, 95.1736f));
+        events.add(new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:40.33"), EventCode.UPDATE, 95.0677f));
+        events.add(new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:51.29"), EventCode.UPDATE, 95.4232f));
+        events.add(new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:59.31"), EventCode.UPDATE, 95.7036f));
+        events.add(new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:59.54"), EventCode.UNDEFINED, 0f));
+
+        Instant begin = TimeUtil.toLocalDT("2019-08-12T00:00:20.0");
+        long stepMilliseconds = 10_000; // ten second sample interval
+        long sampleCount = 5;
+        boolean updatesOnly = true;
+
+        // Generate the expected list
+        List<FloatEvent> exp = new ArrayList<>();
+        exp.add(new FloatEvent(TimeUtil.toMyaTimestamp(begin), EventCode.UPDATE, 94.7978f));
+        exp.add(new FloatEvent(TimeUtil.toMyaTimestamp(begin.plusMillis(stepMilliseconds)), EventCode.UPDATE, 95.6075f));
+        exp.add(new FloatEvent(TimeUtil.toMyaTimestamp(begin.plusMillis(2 * stepMilliseconds)), EventCode.UPDATE, 95.1736f));
+        exp.add(new FloatEvent(TimeUtil.toMyaTimestamp(begin.plusMillis(3 * stepMilliseconds)), EventCode.UPDATE, 95.0677f));
+        exp.add(new FloatEvent(TimeUtil.toMyaTimestamp(begin.plusMillis(4 * stepMilliseconds)), EventCode.UPDATE, 95.7036f));
+
+
+        List<FloatEvent> result = new ArrayList<>();
+        try (EventStream<FloatEvent> stream = new MySamplerStream<>(new ListStream<>(events, FloatEvent.class), begin,
+                stepMilliseconds, sampleCount, priorPoint, updatesOnly, FloatEvent.class)) {
+            FloatEvent event;
+            while ((event = stream.read()) != null) {
+                result.add(event);
+                System.out.println(event);
+            }
+        }
+
+        assertFloatEventListEquals(exp, result);
+    }
+
+    /**
+     * This check tests the behavior when we try to sample from the future.  We should return the last known value
+     * in order to match the behavior of the command line mySampler app.
+     * To make this test repeatable, we sample from a known timestamp with data, e.g. 2019, a timestamp from tomorrow,
+     * and once more from a timestamp is (tomorrow - 2019) time units past tomorrow.
+     *
+     * @throws IOException On error reading from underlying stream
+     */
+    @Test
+    public void futureSampleTest() throws IOException {
+        FloatEvent priorPoint = new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:17.28"), EventCode.UPDATE, 94.7978f);
+        List<FloatEvent> events = new ArrayList<>();
+        events.add(new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:23.32"), EventCode.UPDATE, 95.0715f));
+        events.add(new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:23.42"), EventCode.UPDATE, 0.0715f));
+        events.add(new FloatEvent(TimeUtil.toLocalDT("2019-08-12T00:00:23.52"), EventCode.UPDATE, 1.0715f));
+
+        Instant begin = TimeUtil.toLocalDT("2019-08-12T00:00:20.0");
+        Instant tomorrow = Instant.now().plusMillis(1000 * 60 * 60 * 24);
+        long stepMilliseconds = begin.until(tomorrow, ChronoUnit.MILLIS);
+        long sampleCount = 3;
+        boolean updatesOnly = false;
+
+        List<FloatEvent> exp = new ArrayList<>();
+        exp.add(new FloatEvent(TimeUtil.toMyaTimestamp(begin), EventCode.UPDATE, 94.7978f));
+        exp.add(new FloatEvent(TimeUtil.toMyaTimestamp(begin.plusMillis(stepMilliseconds)), EventCode.UPDATE, 1.0715f));
+        exp.add(new FloatEvent(TimeUtil.toMyaTimestamp(begin.plusMillis(2 * stepMilliseconds)), EventCode.UPDATE, 1.0715f));
+
+        List<FloatEvent> result = new ArrayList<>();
+        try (EventStream<FloatEvent> stream = new MySamplerStream<>(new ListStream<>(events, FloatEvent.class), begin,
+                stepMilliseconds, sampleCount, priorPoint, updatesOnly, FloatEvent.class)) {
+            FloatEvent event;
+            while ((event = stream.read()) != null) {
+                result.add(event);
+                System.out.println(event);
+            }
+        }
+
+        assertFloatEventListEquals(exp, result);
+    }
+
+    /**
+     * Test that the MySamplerStream constructor does not allow null priorPoints (with an empty stream).
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void nullPriorPointTest1() {
+        ListStream<FloatEvent> empty = new ListStream<>(new ArrayList<>(), FloatEvent.class);
+        System.out.println("priorPoint == " + null);
+        new MySamplerStream<>(empty, Instant.now(), 1000, 10, null, false, FloatEvent.class);
+
+        // Should fail if exception is not thrown
+        fail();
+    }
+
+    /**
+     * Test that the MySamplerStream constructor does not allow null priorPoints (with a non-empty stream).
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void nullPriorPointTest2() {
+        Instant now = Instant.now();
+        List<FloatEvent> events = new ArrayList<>();
+        events.add(new FloatEvent(now.plusMillis(100), EventCode.UPDATE, 10));
+        events.add(new FloatEvent(now.plusMillis(200), EventCode.UPDATE, 20));
+        ListStream<FloatEvent> stream = new ListStream<>(events, FloatEvent.class);
+
+        System.out.println("priorPoint == " + null);
+        new MySamplerStream<>(stream, Instant.now(), 1000,10, null, false, FloatEvent.class);
+
+        // Should fail if exception is not thrown
+        fail();
+    }
+
+
+    /**
+     * Check that the sampling works OK with only a single point in the stream.  Same value should be repeated at the
+     * requested sample times
+     *
+     * @throws IOException On error reading from underlying stream
+     */
+    @Test
+    public void singlePointTest() throws IOException {
+        Instant begin = TimeUtil.toLocalDT("2019-08-12T00:00:20.0");
+        long stepMilliseconds = 1000;
+        long sampleCount = 4;
+        boolean updatesOnly = false;
+
+        FloatEvent priorPoint = new FloatEvent(TimeUtil.toMyaTimestamp(begin.minusMillis(1000)),
+                EventCode.UPDATE, 10);
+        System.out.println("Single prior point: " + priorPoint);
+        List<FloatEvent> exp = new ArrayList<>();
+        exp.add(priorPoint.copyTo(begin));
+        exp.add(priorPoint.copyTo(begin.plusMillis(stepMilliseconds)));
+        exp.add(priorPoint.copyTo(begin.plusMillis(2 * stepMilliseconds)));
+        exp.add(priorPoint.copyTo(begin.plusMillis(3 * stepMilliseconds)));
+
+        List<FloatEvent> result = new ArrayList<>();
+        try (EventStream<FloatEvent> stream =
+                     new MySamplerStream<>(new ListStream<>(new ArrayList<>(), FloatEvent.class), begin,
+                             stepMilliseconds, sampleCount, priorPoint, updatesOnly, FloatEvent.class)) {
+            FloatEvent event;
+            while ((event = stream.read()) != null) {
+                result.add(event);
+                System.out.println(event);
+            }
+        }
+
+        assertFloatEventListEquals(exp, result);
+    }
+
+    /**
+     * Test that this stream works with a different Event type than just FloatEvent.  This should be enough to make sure
+     * no FloatEvent specific code has crept in.
+     *
+     * @throws IOException On error reading from underlying stream
+     */
+    @Test
+    public void intEventTest() throws IOException {
+        // The stream to sample from
+        IntEvent priorPoint = new IntEvent(TimeUtil.toLocalDT("2019-08-12T00:00:17.28"), EventCode.UPDATE, 94);
+        List<IntEvent> events = new ArrayList<>();
+        events.add(new IntEvent(TimeUtil.toLocalDT("2019-08-12T00:00:23.32"), EventCode.UPDATE, 95));
+        events.add(new IntEvent(TimeUtil.toLocalDT("2019-08-12T00:00:23.42"), EventCode.UPDATE, 0));
+        events.add(new IntEvent(TimeUtil.toLocalDT("2019-08-12T00:00:23.52"), EventCode.UPDATE, 1));
+        events.add(new IntEvent(TimeUtil.toLocalDT("2019-08-12T00:00:23.62"), EventCode.UPDATE, 2));
+        events.add(new IntEvent(TimeUtil.toLocalDT("2019-08-12T00:00:27.27"), EventCode.UPDATE, 95));
+        events.add(new IntEvent(TimeUtil.toLocalDT("2019-08-12T00:00:32.27"), EventCode.UPDATE, 96));
+        events.add(new IntEvent(TimeUtil.toLocalDT("2019-08-12T00:00:38.32"), EventCode.UPDATE, 90));
+        events.add(new IntEvent(TimeUtil.toLocalDT("2019-08-12T00:00:40.33"), EventCode.UPDATE, 91));
+        events.add(new IntEvent(TimeUtil.toLocalDT("2019-08-12T00:00:47.34"), EventCode.UPDATE, 92));
+        events.add(new IntEvent(TimeUtil.toLocalDT("2019-08-12T00:00:51.29"), EventCode.UPDATE, 93));
+        events.add(new IntEvent(TimeUtil.toLocalDT("2019-08-12T00:00:59.31"), EventCode.UPDATE, 94));
+
+        Instant begin = TimeUtil.toLocalDT("2019-08-12T00:00:20.0");
+        long stepMilliseconds = 10_000; // ten second sample interval
+        long sampleCount = 5;
+        boolean updatesOnly = false;
+
+        // Generate the expected list
+        List<IntEvent> exp = new ArrayList<>();
+        exp.add(new IntEvent(TimeUtil.toMyaTimestamp(begin), EventCode.UPDATE, 94));
+        exp.add(new IntEvent(TimeUtil.toMyaTimestamp(begin.plusMillis(stepMilliseconds)), EventCode.UPDATE, 95));
+        exp.add(new IntEvent(TimeUtil.toMyaTimestamp(begin.plusMillis(2 * stepMilliseconds)), EventCode.UPDATE, 90));
+        exp.add(new IntEvent(TimeUtil.toMyaTimestamp(begin.plusMillis(3 * stepMilliseconds)), EventCode.UPDATE, 92));
+        exp.add(new IntEvent(TimeUtil.toMyaTimestamp(begin.plusMillis(4 * stepMilliseconds)), EventCode.UPDATE, 94));
+
+
+        List<IntEvent> result = new ArrayList<>();
+        try (EventStream<IntEvent> stream = new MySamplerStream<>(new ListStream<>(events, IntEvent.class), begin,
+                stepMilliseconds, sampleCount, priorPoint, updatesOnly, IntEvent.class)) {
+            IntEvent event;
+            while ((event = stream.read()) != null) {
+                result.add(event);
+                System.out.println(event);
+            }
+        }
+
+        assertIntEventListEquals(exp, result);
+    }
+
+
+}

--- a/src/test/java/org/jlab/mya/stream/MySamplerStreamTest.java
+++ b/src/test/java/org/jlab/mya/stream/MySamplerStreamTest.java
@@ -28,7 +28,8 @@ public class MySamplerStreamTest {
         // Event does not define equals, so this is about as good as it gets.
         assertEquals("Received a different number of events than expected", exp.size(), result.size());
         for (int i = 0; i < exp.size(); i++) {
-            assertEquals("Mismatch at event " + i, exp.get(i).toString(), result.get(i).toString());
+            assertEquals( "Value mismatch at event " + i, exp.get(i).getValue(), result.get(i).getValue(), 0.001);
+            assertEquals( "Timestamp mismatch at event " + i, exp.get(i).getTimestamp(), result.get(i).getTimestamp());
         }
     }
 

--- a/src/test/java/org/jlab/mya/stream/MySamplerStreamTest.java
+++ b/src/test/java/org/jlab/mya/stream/MySamplerStreamTest.java
@@ -44,7 +44,8 @@ public class MySamplerStreamTest {
         // Event does not define equals, so this is about as good as it gets.
         assertEquals("Received a different number of events than expected", exp.size(), result.size());
         for (int i = 0; i < exp.size(); i++) {
-            assertEquals("Mismatch at event " + i, exp.get(i).toString(), result.get(i).toString());
+            assertEquals( "Value mismatch at event " + i, exp.get(i).getValue(), result.get(i).getValue());
+            assertEquals( "Timestamp mismatch at event " + i, exp.get(i).getTimestamp(), result.get(i).getTimestamp());
         }
     }
 


### PR DESCRIPTION
This update includes an service that performs a mySampler compatible sampling of an event stream based on the BoundaryAwareStream class.  Unit tests included.

The old method for getting a mySampler like stream is left intact for backwards compatibility.  Documentation about deprecation, etc. may need to be added.  The old method did not update time stamps when returning the sampled stream, while the new method generates artificial Event objects at the sample times.  The new method also supports multiple event types, not just FloatEvents.