### PR TITLE
Increment version number. 6.4.0 is not backwards compatible.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 description = 'Java MYA API'
 group 'org.jlab'
-version '6.4.0'
+version '7.0.0'
 
 tasks.withType(JavaCompile) {
     options.release = 8


### PR DESCRIPTION
I will delete v6.4.0 release and keep only v7.0.0.